### PR TITLE
[RFC] Initial spell drop for DE attack

### DIFF
--- a/COCBot/CGB Functions.au3
+++ b/COCBot/CGB Functions.au3
@@ -23,6 +23,7 @@
 #include "functions\Attack\CheckHeroesHealth.au3"
 #include "functions\Attack\dropCC.au3"
 #include "functions\Attack\dropHeroes.au3"
+#include "functions\Attack\dropSpell.au3"
 #include "functions\Attack\GoldElixirChange.au3"
 #include "functions\Attack\GoldElixirChangeEBO.au3"
 #include "functions\Attack\PrepareAttack.au3"

--- a/COCBot/CGB Global Variables.au3
+++ b/COCBot/CGB Global Variables.au3
@@ -219,6 +219,9 @@ Global $fullArmy ;Check for full army or not
 Global $iChkDeploySettings[$iModeCount] ;Method of deploy found in attack settings
 Global $iChkRedArea[$iModeCount], $iCmbSmartDeploy[$iModeCount], $iChkSmartAttack[$iModeCount][3], $iCmbSelectTroop[$iModeCount]
 
+Global $iChkDEUseSpell
+Global $iChkDEUseSpellType
+
 Global $troopsToBeUsed[11]
 Global $useAllTroops[24] = [$eBarb, $eArch, $eGiant, $eGobl, $eWall, $eBall, $eWiza, $eHeal, $eDrag, $ePekk, $eMini, $eHogs, $eValk, $eGole, $eWitc, $eLava, $eKing, $eQueen, $eCastle, $eLSpell, $eHSpell, $eRSpell, $eJSpell, $eFSpell]
 Global $useBarracks[18] = [$eBarb, $eArch, $eGiant, $eGobl, $eWall, $eBall, $eWiza, $eHeal, $eDrag, $ePekk, $eKing, $eQueen, $eCastle, $eLSpell, $eHSpell, $eRSpell, $eJSpell, $eFSpell]
@@ -569,6 +572,7 @@ Global $DEEdge, $DarkLow
 Global $saveiChkTimeStopAtk, $saveiChkTimeStopAtk2, $saveichkEndOneStar, $saveichkEndTwoStars
 Global $DESideEB, $DELowEndMin, $DisableOtherEBO
 Global $DEEndAq, $DEEndBk, $DEEndOneStar
+Global $SpellDP[2] = [0, 0]; Spell drop point for DE attack
 ;Location for BK & AQ for boosting
 Global $KingPos[2], $QueenPos[2]
 ;Hero Healing Filter

--- a/COCBot/GUI/CGB GUI Design Tab Attack.au3
+++ b/COCBot/GUI/CGB GUI Design Tab Attack.au3
@@ -121,7 +121,7 @@ $tabAttack = GUICtrlCreateTabItem("Attack")
 		$chkABRandomSpeedAtk = GUICtrlCreateCheckbox("Randomize delay for Units && Waves", $x, $y, -1, -1)
 			GUICtrlSetTip(-1, $txtTip)
 			GUICtrlSetOnEvent(-1, "chkABRandomSpeedAtk")
-	$y = 250
+	$y = 240
 		$chkABSmartAttackRedArea = GUICtrlCreateCheckbox("Use Smart Attack: Near Red Line.", $x, $y, -1, -1)
 			$txtTip = "Use Smart Attack to detect the outer 'Red Line' of the village to attack. And drop your troops close to it."
 			GUICtrlSetTip(-1, $txtTip)
@@ -154,6 +154,12 @@ $tabAttack = GUICtrlCreateTabItem("Attack")
  			GUICtrlSetTip(-1, $txtTip)
 		$picABAttackNearDarkElixirDrill = GUICtrlCreateIcon($pIconLib, $eIcnDrill, $x + 20 , $y - 3, 24, 24)
  			GUICtrlSetTip(-1, $txtTip)
+		$y += 22
+		$chkABDEUseSpell = GUICtrlCreateCheckbox("DE attack Spell:",$x - 130, $y, -1 , -1)
+			$txtTip = "Drop spell while doing DE attack (only work with DE side attack ATM)"
+ 			GUICtrlSetTip(-1, $txtTip)
+		$cmbABDEUseSpellType = GUICtrlCreateCombo("", $x - 30, $y, 95, -1, BitOR($CBS_DROPDOWNLIST, $CBS_AUTOHSCROLL))
+			GUICtrlSetData(-1, "Healing|Rage", "Heal")
 	$x -= 70
 	$y = 335
 		GUICtrlCreateIcon($pIconLib, $eIcnKing, $x, $y, 24, 24)
@@ -171,8 +177,8 @@ $tabAttack = GUICtrlCreateTabItem("Attack")
 			GUICtrlSetTip(-1, "Drop your Clan Castle in battle if it contains troops.")
 	GUICtrlCreateGroup("", -99, -99, 1, 1)
 
-	Local $x = 200, $y = 345
-	$grpClanCastleBal = GUICtrlCreateGroup("ClanCastle Balance", $x - 20, $y - 20, 110, 100)
+	Local $x = 200, $y = 350
+	$grpClanCastleBal = GUICtrlCreateGroup("ClanCastle Balance", $x - 20, $y - 20, 110, 95)
 		GUICtrlCreateLabel("", $x - 18, $y - 7, 106, 85) ; fake label to hide group border from DB and LB setting groups
 		GUICtrlSetBkColor (-1, $COLOR_WHITE)
 		GUICtrlSetState (-1, $GUI_DISABLE)

--- a/COCBot/functions/Attack/Attack Algorithms/algorithm_AllTroops.au3
+++ b/COCBot/functions/Attack/Attack Algorithms/algorithm_AllTroops.au3
@@ -132,7 +132,7 @@ Func algorithm_AllTroops() ;Attack Algorithm for all existing troops
 	If _Sleep(1000) Then Return
 
 	If $iMatchMode = $LB And $iChkDeploySettings[$LB] = 4 Then   ; Customise DE side wave deployment here
-		Local $listInfoDeploy[13][5] = [[$eGiant, $nbSides, 1, 1, 0] _
+		Local $listInfoDeploy[14][5] = [[$eGiant, $nbSides, 1, 1, 0] _
 			, [$eWall, $nbSides, 1, 1, 1] _
 			, [$eBarb, $nbSides, 1, 2, 0] _
 			, [$eArch, $nbSides, 1, 3, 0] _
@@ -140,6 +140,7 @@ Func algorithm_AllTroops() ;Attack Algorithm for all existing troops
 			, [$eArch, $nbSides, 2, 3, 0] _
 			, ["CC", 1, 1, 1, 1] _
 			, ["HEROES", 1, 2, 1, 0] _
+			, ["SPELL", 1, 1, 1, 1] _
 			, [$eHogs, $nbSides, 1, 1, 1] _
 			, [$eWiza, $nbSides, 1, 1, 0] _
 			, [$eMini, $nbSides, 1, 1, 0] _

--- a/COCBot/functions/Attack/DESide.au3
+++ b/COCBot/functions/Attack/DESide.au3
@@ -1,19 +1,80 @@
+Func DESpellDP()
+	local $xLimit = 0
+	local $yLimit = 0
+	local $HSDist[2] = [60, 55]
+	local $MaxDist[2] = [90, 90]
+	$SpellDP[0] = 0
+	$SpellDP[1] = 0
+
+	If $DESLoc = 0 Then
+		; assume the DE is in the center
+		$DESLocx = $MapCenter[0]
+		$DESLocy = $MapCenter[1]
+	Endif
+	If $DEEdge = 0 Then
+		$xLimit = $MapCenter[0] + $MaxDist[0]
+		$yLimit = $MapCenter[1] + $MaxDist[1]
+		$SpellDP[0] = $DESLocx + $HSDist[0]
+		$SpellDP[1] = $DESLocy + $HSDist[1]
+		if $SpellDP[0] > $xLimit Then
+			$SpellDP[0] = $xLimit
+		Endif
+		if $SpellDP[1] >  $yLimit Then
+			$SpellDP[1] = $yLimit
+		Endif
+	ElseIf $DEEdge = 3 Then
+		$xLimit = $MapCenter[0] + $MaxDist[0]
+		$yLimit = $MapCenter[1] - $MaxDist[1]
+		$SpellDP[0] = $DESLocx + $HSDist[0]
+		$SpellDP[1] = $DESLocy - $HSDist[1]
+		if $SpellDP[0] > $xLimit Then
+			$SpellDP[0] = $xLimit
+		Endif
+		if $SpellDP[1] < $yLimit  Then
+			$SpellDP[1] = $yLimit
+		Endif
+	ElseIf $DEEdge = 1 Then
+		$xLimit = $MapCenter[0] - $MaxDist[0]
+		$yLimit = $MapCenter[1] - $MaxDist[1]
+		$SpellDP[0] = $DESLocx - $HSDist[0]
+		$SpellDP[1] = $DESLocy - $HSDist[1]
+		if $SpellDP[0] < $xLimit Then
+			$SpellDP[0] = $xLimit
+		Endif
+		if $SpellDP[1] <  $yLimit Then
+			$SpellDP[1] = $yLimit
+		Endif
+	ElseIf $DEEdge = 2 Then
+		$xLimit = $MapCenter[0] - $MaxDist[0]
+		$yLimit = $MapCenter[1] + $MaxDist[1]
+		$SpellDP[0] = $DESLocx - $HSDist[0]
+		$SpellDP[1] = $DESLocy + $HSDist[1]
+		if $SpellDP[0] < $xLimit Then
+			$SpellDP[0] = $xLimit
+		Endif
+		if $SpellDP[1] > $yLimit  Then
+			$SpellDP[1] = $yLimit
+		Endif
+	EndIf
+	SetLog ("Spell drop point: " & $SpellDP[0] & ", " & $SpellDP[1] , $COLOR_BLUE)
+EndFunc	;==>DESpellDP
+
 Func GetDEEdge() ;Using $DESLoc x y we are finding which side de is located.
 	DExy()
 	If $DESLoc = 1 Then
-		If ($DESLocx = 430) And ($DESLocy = 313) Then
+		If ($DESLocx = $MapCenter[0]) And ($DESLocy = $MapCenter[1]) Then
 			SetLog("DE Storage Located in Middle... Attacking Random Side", $COLOR_BLUE)
 			$DEEdge = (Random(Round(0, 3)))
-		ElseIf ($DESLocx >= 430) And ($DESLocy >= 313) Then
+		ElseIf ($DESLocx >= $MapCenter[0]) And ($DESLocy >= $MapCenter[1]) Then
 			SetLog("DE Storage Located Bottom Right... Attacking Bottom Right", $COLOR_BLUE)
 			$DEEdge = 0
-		ElseIf ($DESLocx > 430) And ($DESLocy < 313) Then
+		ElseIf ($DESLocx > $MapCenter[0]) And ($DESLocy < $MapCenter[1]) Then
 			SetLog("DE Storage Located Top Right... Attacking Top Right", $COLOR_BLUE)
 			$DEEdge = 3
-		ElseIf ($DESLocx <= 430) And ($DESLocy <= 313) Then
+		ElseIf ($DESLocx <= $MapCenter[0]) And ($DESLocy <= $MapCenter[1]) Then
 			SetLog("DE Storage Located Top Left... Attacking Top Left", $COLOR_BLUE)
 			$DEEdge = 1
-		ElseIf ($DESLocx < 430) And ($DESLocy > 313) Then
+		ElseIf ($DESLocx < $MapCenter[0]) And ($DESLocy > $MapCenter[1]) Then
 			SetLog("DE Storage Located Bottom Left... Attacking Bottom Left", $COLOR_BLUE)
 			$DEEdge = 2
 		EndIf

--- a/COCBot/functions/Attack/Troops/LauchTroop.au3
+++ b/COCBot/functions/Attack/Troops/LauchTroop.au3
@@ -195,7 +195,7 @@ Func LaunchTroop2($listInfoDeploy, $CC, $King, $Queen)
 		Next
 	Else
 		For $i = 0 To UBound($listInfoDeploy) - 1
-			If (IsString($listInfoDeploy[$i][0]) And ($listInfoDeploy[$i][0] = "CC" Or $listInfoDeploy[$i][0] = "HEROES")) Then
+			If (IsString($listInfoDeploy[$i][0]) And ($listInfoDeploy[$i][0] = "CC" Or $listInfoDeploy[$i][0] = "HEROES" Or $listInfoDeploy[$i][0] = "SPELL")) Then
 				If $iMatchMode = $LB And $iChkDeploySettings[$LB] = 4 Then
 					Local $RandomEdge = $Edges[$DEEdge]
 					Local $RandomXY = 2
@@ -207,6 +207,16 @@ Func LaunchTroop2($listInfoDeploy, $CC, $King, $Queen)
 					dropCC($RandomEdge[$RandomXY][0], $RandomEdge[$RandomXY][1], $CC)
 				ElseIf ($listInfoDeploy[$i][0] = "HEROES") Then
 					dropHeroes($RandomEdge[$RandomXY][0], $RandomEdge[$RandomXY][1], $King, $Queen)
+				ElseIf ($listInfoDeploy[$i][0] = "SPELL") Then
+					If $iChkDEUseSpell = 1 Then
+						If $iChkDEUseSpellType = 0 Then
+							local $spell = $eHSpell
+						ElseIf $iChkDEUseSpellType = 1 Then
+							local $spell = $eRSpell
+						EndIf
+						DESpellDP()
+						dropSpell($SpellDP[0], $SpellDP[1], $spell)
+					EndIf
 				EndIf
 			Else
 				If LauchTroop($listInfoDeploy[$i][0], $listInfoDeploy[$i][1], $listInfoDeploy[$i][2], $listInfoDeploy[$i][3], $listInfoDeploy[$i][4]) Then

--- a/COCBot/functions/Attack/dropSpell.au3
+++ b/COCBot/functions/Attack/dropSpell.au3
@@ -1,0 +1,32 @@
+;Drops Clan Castle troops, given the slot and x, y coordinates.
+
+; #FUNCTION# ====================================================================================================================
+; Name ..........: dropSpell
+; Description ...: Drops Spell, given the spell and x, y coordinates.
+; Syntax ........: dropSpell($x, $y, $spell)
+; Parameters ....: $x                   - X location.
+;                  $y                   - Y location.
+;                  $spell               - spell
+; Return values .: None
+; Author ........:
+; Modified ......:
+; Remarks .......: This file is part of ClashGameBot. Copyright 2015
+;                  ClashGameBot is distributed under the terms of the GNU GPL
+; Related .......:
+; Link ..........:
+; Example .......: No
+; ===============================================================================================================================
+Func dropSpell($x, $y, $spell) ;Drop Spell
+	If $spell <> -1 Then
+		For $i = 0 To 8
+			If $atkTroops[$i][0] = $spell Then
+				If _Sleep(100) Then Return
+				SetLog("Dropping spell in slot " & $i, $COLOR_BLUE)
+				Click(68 + (72 * $i), 595) ;Select spell (FIXME: add debug info)
+				If _Sleep(500) Then Return
+				Click($x, $y) ; drop it (FIXME: add debug info)
+				exitloop
+			Endif
+		Next
+	EndIf
+EndFunc   ;==>dropSpell

--- a/COCBot/functions/Config/ScreenCoordinates.au3
+++ b/COCBot/functions/Config/ScreenCoordinates.au3
@@ -121,3 +121,5 @@ Global Const $GemGole[4]   = [ 559, 378, 0xE70A12, 30]
 Global Const $GemWitc[4]   = [ 666, 372, 0xE70A12, 30]
 
 Global Const $GemLava[4]   = [ 239, 372, 0xE70A12, 30]
+
+Global Const $MapCenter[2] = [430, 313] ; Map center location

--- a/COCBot/functions/Config/applyConfig.au3
+++ b/COCBot/functions/Config/applyConfig.au3
@@ -354,6 +354,13 @@ Func applyConfig() ;Applies the data from config to the controls in GUI
 		GUICtrlSetState($chkABAttackNearDarkElixirDrill, $GUI_UNCHECKED)
 	EndIf
 
+	If $iChkDEUseSpell = 1 Then
+		GUICtrlSetState($chkABDEUseSpell, $GUI_CHECKED)
+	Else
+		GUICtrlSetState($chkABDEUseSpell, $GUI_UNCHECKED)
+	EndIf
+	_GUICtrlComboBox_SetCurSel($cmbABDEUseSpellType, $iChkDEUseSpellType)
+
 	If $KingAttack[$DB] = 1 Then
 		GUICtrlSetState($chkDBKingAttack, $GUI_CHECKED)
 	Else

--- a/COCBot/functions/Config/readConfig.au3
+++ b/COCBot/functions/Config/readConfig.au3
@@ -174,6 +174,9 @@ Func readConfig() ;Reads config and sets it to the variables
 		$iChkSmartAttack[$LB][1] = IniRead($config, "attack", "ABSmartAttackElixirCollector", "0")
 		$iChkSmartAttack[$LB][2] = IniRead($config, "attack", "ABSmartAttackDarkElixirDrill", "0")
 
+		$iChkDEUseSpell = IniRead($config, "attack", "ABDEUseSpell", "0")
+		$iChkDEUseSpellType = IniRead($config, "attack", "ABDEUseSpellType", "0")
+
 		$KingAttack[$DB] = IniRead($config, "attack", "DBKingAtk", "0")
 		$KingAttack[$LB] = IniRead($config, "attack", "ABKingAtk", "0")
 

--- a/COCBot/functions/Config/saveConfig.au3
+++ b/COCBot/functions/Config/saveConfig.au3
@@ -317,6 +317,14 @@ Func saveConfig() ;Saves the controls settings to the config
 		IniWrite($config, "attack", "ABSmartAttackDarkElixirDrill", 0)
 	EndIf
 
+	If GUICtrlRead($chkABDEUseSpell) = $GUI_CHECKED Then
+		IniWrite($config, "attack", "ABDEUseSpell", 1)
+	Else
+		IniWrite($config, "attack", "ABDEUseSpell", 0)
+	EndIf
+
+	IniWrite($config, "attack", "ABDEUseSpellType", _GUICtrlComboBox_GetCurSel($cmbABDEUseSpellType))
+
 	If GUICtrlRead($chkDBKingAttack) = $GUI_CHECKED Then
 		IniWrite($config, "attack", "DBKingAtk", 1)
 	Else

--- a/COCBot/functions/Village/Train.au3
+++ b/COCBot/functions/Village/Train.au3
@@ -710,7 +710,7 @@ Func Train()
 	EndIf
 
 
-	If $iChkLightSpell = 1 Then
+	If $iChkLightSpell = 1 or $iChkDEUseSpell = 1 Then
 		$iBarrHere = 0
 		While Not isSpellFactory()
 			If IsArray($PrevPos) Then Click($PrevPos[0], $PrevPos[1], 1, 0, "#0323") ;click prev button
@@ -721,32 +721,41 @@ Func Train()
 
 		If isSpellFactory() Then
 			Local $x = 0
-			While 1
-				_CaptureRegion()
-				If _sleep(500) Then Return
-				If _ColorCheck(_GetPixelColor(237, 354, True), Hex(0xFFFFFF, 6), 20) = False Then
-					setlog("Not enough Elixir to create Spell", $COLOR_RED)
-					ExitLoop
-				ElseIf _ColorCheck(_GetPixelColor(200, 346, True), Hex(0x1A1A1A, 6), 20) Then
-					setlog("Spell Factory Full", $COLOR_RED)
-					ExitLoop
-				Else
-					GemClick(252, 354, 1, 20, "#0290")
-					$x = $x + 1
-				EndIf
+			local $Spellslot = -1
+			If $iChkLightSpell = 1 Then
+				$Spellslot = 0
+			ElseIf $iChkDEUseSpell = 1 Then
+				$Spellslot = $iChkDEUseSpellType + 1
+				; only work on Heal Spell for now, until the Healing and Rage Spell is correctly detected
+				$Spellslot = 1
+			EndIf
+			If $Spellslot <> -1 Then
+				While 1
+					_CaptureRegion()
+					If _sleep(500) Then Return
+					; FixME: what is the detection for Not enough Elixir
+					;If _ColorCheck(_GetPixelColor(237, 354, True), Hex(0x8A8A8A, 6), 20) =  Then
+					;	setlog("Not enough Elixir to create Spell", $COLOR_RED)
+					;	ExitLoop
+					If _ColorCheck(_GetPixelColor(200, 346, True), Hex(0x414141, 6), 20) Then
+						setlog("Spell Factory Full", $COLOR_RED)
+						ExitLoop
+					Else
+						GemClick(252 + ($Spellslot * 105), 354, 1, 20, "#0290")
+						$x = $x + 1
+					EndIf
+					If $x = 5 Then
+						ExitLoop
+					EndIf
+				WEnd
 				If $x = 5 Then
-					ExitLoop
+				Else
+					SetLog("Created " & $x & " Spell(s)", $COLOR_BLUE)
 				EndIf
-			WEnd
-			If $x = 0 Then
-			Else
-				SetLog("Created " & $x & " Lightning Spell(s)", $COLOR_BLUE)
 			EndIf
 		Else
 			SetLog("Spell Factory not found...", $COLOR_BLUE)
 		EndIf
-	Else
-
 	EndIf ; End Spell Factory
 
 	If _Sleep(200) Then Return

--- a/COCBot/functions/Village/isBarrack.au3
+++ b/COCBot/functions/Village/isBarrack.au3
@@ -54,11 +54,14 @@ Func isSpellFactory()
 	If _ColorCheck(_GetPixelColor(640, 530, True), Hex(0xeceee8, 6), 10)  Then
 		if $debugSetlog = 1 then SetLog("Spell FactoryDark  selected")
 		Return True ;Spell Factory
-		EndIf
-Return True ;Spell
+	EndIf
+	Return False
+EndFunc   ;==>isSpellFactory
+
+Func isDarkSpellFactory()
 	If _ColorCheck(_GetPixelColor(700, 530, True), Hex(0xeceee8, 6), 10)  Then
 		if $debugSetlog = 1 then SetLog("Dark Spell Factory  selected")
 		Return True ;dark Spell Factory
-		EndIf
+	EndIf
 	Return False
-EndFunc   ;==>isSpellFactory
+EndFunc   ;==>isDarkSpellFactory


### PR DESCRIPTION
During the battle, bot drops a spell base on the DE storage detection.

Drop either HEAL or Rage Spell during DE attack method. However, it only
drops Heal at this point as img detection for Healing and Rage Spell is
incorrect at this time.

Spell creation needs to be fixed for "Not enough Elixir" detection.

Signed-off-by: kaluba <kaluba>